### PR TITLE
fix(onlineTextEnhance): ドキュメントがすでに読み込まれている場合でも確実に処理を行うように

### DIFF
--- a/src/olt_enhance.ts
+++ b/src/olt_enhance.ts
@@ -4,8 +4,8 @@
     console.log("[Moodle Plus] olt enhance script loaded. Waiting for page load");
 
     // atto editorがマウントされるまで待つ
-    window.addEventListener('load', () => {
-
+    function onLoad() {
+        console.log("[Moodle Plus] Page loaded. Start enhancing OLT");
         const attoEditor = document.querySelectorAll('.editor_atto_wrap');
         if (attoEditor.length === 0) return;
 
@@ -38,5 +38,11 @@
                 count.textContent = `文字数: ${getTextLengthInEl(content)}`;
             }, { passive: true });
         });
-    });
+    }
+
+    if (document.readyState !== 'complete') {
+        window.addEventListener('load', onLoad);
+    } else {
+        onLoad();
+    }
 })();

--- a/src/olt_enhance.ts
+++ b/src/olt_enhance.ts
@@ -5,7 +5,7 @@
 
     // atto editorがマウントされるまで待つ
     function onLoad() {
-        console.log("[Moodle Plus] Page loaded. Start enhancing OLT");
+        console.log("[Moodle Plus] Page loaded. Start enhancing Atto editor");
         const attoEditor = document.querySelectorAll('.editor_atto_wrap');
         if (attoEditor.length === 0) return;
 


### PR DESCRIPTION
## What
`window.addEventListener('load')` の実行時期がすでに済んでいる場合は再度イベントが発行されることがない。そのため、`document.readyState`ですでにonloadが実行されているかどうかを判断して、実行がすんでいた場合は即時カウンタを有効にするように

## Why
Firefoxで文字数カウンタの読み込みに失敗したため