### PR TITLE
feat: meaQsの出力強化機能の追加

### DIFF
--- a/leaQs.html
+++ b/leaQs.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1.0">
+    <title>leaQs</title>
+    <link rel="stylesheet" href="styles/leaQs.css">
+</head>
+
+<body>
+    <div id="info"></div>
+    <div id="container"> </div>
+    <script src="dist/leaQs.js"></script>
+</body>
+
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
                 "https://cms.aitech.ac.jp/*"
             ],
             "js": [
-                "./dist/content_script_injector.js"
+                "./dist/content_script_injector.js",
+                "./dist/leaQs_contents.js"
             ],
             "css": [
                 "./styles/main.css"
@@ -44,5 +45,8 @@
                 "https://cms.aitech.ac.jp/*"
             ]
         }
-    ]
+    ],
+    "background": {
+        "service_worker": "dist/background.js"
+    }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -12,7 +12,7 @@
     });
 
     async function formatAndDisplayQuiz(
-        quizData: Quiz[],
+        quizData: MeaQsQuiz[],
         className: string,
         sectionName: string
     ) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,36 @@
+/// <reference types="chrome"/>
+/// <reference path="types.d.ts" />
+(() => {
+    chrome.runtime.onMessage.addListener((request) => {
+        if (request.action === "formatAndDisplayQuiz") {
+            formatAndDisplayQuiz(
+                request.quizData,
+                request.className,
+                request.sectionName
+            );
+        }
+    });
+
+    async function formatAndDisplayQuiz(
+        quizData: Quiz[],
+        className: string,
+        sectionName: string
+    ) {
+        try {
+            const tab = await chrome.tabs.create({ url: "leaQs.html" });
+            const classAndSection = className + "/ " + sectionName;
+            chrome.tabs.onUpdated.addListener(function listener(tabId, info) {
+                if (tabId === tab.id && info.status === "complete") {
+                    chrome.tabs.onUpdated.removeListener(listener);
+                    chrome.tabs.sendMessage(tabId, {
+                        action: "displaySummary",
+                        quizData: quizData,
+                        classAndSection: classAndSection,
+                    });
+                }
+            });
+        } catch (error) {
+            console.error("Error creating new tab:", error);
+        }
+    }
+})();

--- a/src/leaQs.ts
+++ b/src/leaQs.ts
@@ -1,0 +1,120 @@
+/// <refarence types="chrome"/>
+/// <reference path="./types.d.ts" />
+(() => {
+    chrome.runtime.onMessage.addListener((request) => {
+        if (request.action === "displaySummary") {
+            displaySummary(request.quizData, request.classAndSection);
+        }
+    });
+
+    function displaySummary(quizData: Quiz[], classAndSection: string) {
+        const container = document.getElementById("container");
+
+        // クラスとセクション情報を表示
+        const header = document.createElement("h1");
+        header.textContent = `${classAndSection}`;
+        const info = document.getElementById("info");
+        if (info) {
+            info.appendChild(header);
+        }
+
+        // クイズデータを表示
+        quizData.forEach((quiz, index) => {
+            if (quiz.index !== index) {
+                const errorElement = document.createElement("p");
+                errorElement.textContent = `Error: Quiz index mismatch. Expected: ${index}, Actual: ${quiz.index}`;
+                errorElement.style.color = "red";
+                errorElement.style.fontWeight = "bold";
+                if (container) {
+                    container.appendChild(errorElement);
+                }
+            }
+            const quizElement = document.createElement("div");
+            quizElement.classList.add("quiz-item");
+
+            const questionNumElement = document.createElement("h2");
+            questionNumElement.textContent = `（${index + 1}）`;
+            quizElement.appendChild(questionNumElement);
+            quizElement.appendChild(
+                createDiv(quiz.question, ["quiz-question"])
+            );
+
+            if (quiz.image) {
+                for (let i = 0; i < quiz.image.length; i++) {
+                    if (i <= quiz.question.length + 1) {
+                        const imageElement = document.createElement("img");
+                        imageElement.src = quiz.image[i];
+                        imageElement.alt = `問題の画像 #${i + 1} `;
+                        quizElement.appendChild(imageElement);
+                    }
+                }
+            }
+
+            if (quiz.choices.length !== 0) {
+                const choicesElement = document.createElement("ul");
+                quiz.choices.forEach((choice: string[]) => {
+                    const choiceItem = document.createElement("li");
+                    choice.forEach((text) => {
+                        const textElement = document.createElement("p");
+                        textElement.textContent = text;
+                        choiceItem.appendChild(textElement);
+                    });
+                    choicesElement.appendChild(choiceItem);
+                });
+                quizElement.appendChild(choicesElement);
+                if (quiz.correct && quiz.answer) {
+                    const correctElement = document.createElement("div");
+                    correctElement.textContent = `正解: `;
+                    correctElement.appendChild(
+                        createDiv(quiz.correct, ["quiz-example"])
+                    );
+                    quizElement.appendChild(correctElement);
+                    const answerElement = document.createElement("div");
+                    answerElement.textContent = `回答: `;
+                    if (
+                        createDiv(quiz.correct, ["quiz-example"])
+                            .textContent !==
+                        createDiv(quiz.answer, ["quiz-example"]).textContent
+                    ) {
+                        answerElement.appendChild(
+                            createDiv(quiz.answer, [
+                                "quiz-userAnswer-incorrect",
+                            ])
+                        );
+                        quizElement.appendChild(answerElement);
+                    }
+                }
+            } else {
+                if (quiz.correct && quiz.answer) {
+                    const correctElement = document.createElement("div");
+                    correctElement.textContent = `正解: `;
+                    correctElement.appendChild(
+                        createDiv(quiz.correct, ["quiz-example"])
+                    );
+                    quizElement.appendChild(correctElement);
+                    const answerElement = document.createElement("div");
+                    answerElement.textContent = `回答: `;
+                    answerElement.appendChild(
+                        createDiv(quiz.answer, ["quiz-userAnswer-correct"])
+                    );
+                    quizElement.appendChild(answerElement);
+                }
+            }
+
+            if (container) {
+                container.appendChild(quizElement);
+            }
+        });
+    }
+
+    function createDiv(target: any[], [className]: [string]) {
+        const functionElement = document.createElement("div");
+        functionElement.classList.add(className);
+        target.forEach((item) => {
+            const itemTextElement = document.createElement("p");
+            itemTextElement.textContent = item;
+            functionElement.appendChild(itemTextElement);
+        });
+        return functionElement;
+    }
+})();

--- a/src/leaQs.ts
+++ b/src/leaQs.ts
@@ -7,7 +7,7 @@
         }
     });
 
-    function displaySummary(quizData: Quiz[], classAndSection: string) {
+    function displaySummary(quizData: MeaQsQuiz[], classAndSection: string) {
         const container = document.getElementById("container");
 
         // クラスとセクション情報を表示

--- a/src/leaQs_contents.ts
+++ b/src/leaQs_contents.ts
@@ -50,13 +50,13 @@
     }
 
     function extractQuizElements() {
-        const quizzes: Quiz[] = [];
+        const quizzes: MeaQsQuiz[] = [];
         const quizContainers = document.querySelectorAll(
             ".fcontainer.clearfix"
         );
 
         quizContainers.forEach((container, index) => {
-            const quiz: Quiz = {
+            const quiz: MeaQsQuiz = {
                 index: index,
                 question: [],
             };

--- a/src/leaQs_contents.ts
+++ b/src/leaQs_contents.ts
@@ -1,0 +1,328 @@
+(() => {
+    const targetUrl = "https://lms.omu.ac.jp/mod/meaqs/student/appraisals.php?";
+    if (window.location.href.startsWith(targetUrl)) {
+        createLeaQsPDFButton();
+    }
+
+    function createLeaQsPDFButton() {
+        const pdfButton = document.getElementById("pdf_button");
+        if (!pdfButton) return;
+
+        const parentDiv = pdfButton?.parentNode;
+        if (!parentDiv) return;
+
+        const button = document.createElement("button");
+        button.className = "btn btn-info";
+        button.textContent = "leaQs";
+        button.style.padding = "9px 18px";
+        button.style.backgroundColor = "#327ab7";
+        button.style.color = "#fff";
+        button.style.border = "none";
+        button.style.cursor = "pointer";
+
+        const spacer = document.createTextNode(" ");
+
+        try {
+            parentDiv.insertBefore(button, pdfButton.nextSibling);
+            parentDiv.insertBefore(spacer, pdfButton.nextSibling);
+        } catch (e) {
+            console.error("Error inserting button:", e);
+            return;
+        }
+
+        button.addEventListener("click", () => {
+            try {
+                const quizData = extractQuizElements();
+                const pageNavbar = document.querySelector("#page-navbar");
+                const className = pageNavbar?.querySelector("a")?.title ?? "";
+                const sectionName =
+                    pageNavbar?.querySelector("span")?.textContent ?? "";
+                chrome.runtime.sendMessage({
+                    action: "formatAndDisplayQuiz",
+                    quizData: quizData,
+                    className: className,
+                    sectionName: sectionName,
+                });
+            } catch (error) {
+                console.error("Runtime error:", error);
+            }
+        });
+    }
+
+    function extractQuizElements() {
+        const quizzes: Quiz[] = [];
+        const quizContainers = document.querySelectorAll(
+            ".fcontainer.clearfix"
+        );
+
+        quizContainers.forEach((container, index) => {
+            const quiz: Quiz = {
+                index: index,
+                question: [],
+            };
+            // 質問の抽出
+            const questionNodes =
+                container.querySelector(".form-control-static .text_to_html")
+                    ?.childNodes ?? [];
+            if (questionNodes.length >= 0) {
+                for (let i = 0; i < questionNodes.length; i += 1) {
+                    const questionNode = questionNodes[i]?.textContent?.replace(
+                        /\s+/g,
+                        ""
+                    );
+                    if (questionNode !== undefined) {
+                        quiz.question.push(questionNode);
+                    }
+                }
+            }
+
+            // 選択肢の抽出
+            const choiceElements =
+                container.querySelectorAll(".radio").length !== 0
+                    ? container.querySelectorAll(".radio")
+                    : container.querySelectorAll(".checkbox");
+            quiz.choices = [];
+            if (choiceElements) {
+                for (let i = 0; i < choiceElements.length; i += 1) {
+                    const choices = choiceElements[i];
+                    const choiceChilds = choices.childNodes;
+                    const text = [];
+                    for (let j = 0; j < choiceChilds.length; j += 1) {
+                        const textChild = choiceChilds[j];
+                        if (textChild.nodeType === 1) {
+                            const textNode = (
+                                textChild as Element
+                            ).getElementsByTagName("p");
+                            if (textNode.length !== 0) {
+                                for (let k = 0; k < textNode.length; k += 1) {
+                                    text.push(textNode[k].textContent);
+                                }
+                            } else {
+                                const textToHtmlElement = (
+                                    textChild as Element
+                                )?.querySelector(
+                                    ".text_to_html"
+                                ) as Element | null;
+                                if (textToHtmlElement) {
+                                    const textContent =
+                                        textToHtmlElement?.textContent;
+                                    if (textContent) {
+                                        text.push(textContent);
+                                    }
+                                } else {
+                                    const textContent = textChild.textContent;
+                                    if (textContent) {
+                                        text.push(textContent);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    quiz.choices.push(text);
+
+                    // 選択肢問題の正答を取得
+                    if (choices.querySelector("strong .text_to_html")) {
+                        const correct = choices.querySelector("strong");
+                        const correctChilds = correct ? correct.childNodes : [];
+                        const text = [];
+                        for (let j = 0; j < correctChilds.length; j += 1) {
+                            const textChild = correctChilds[j];
+                            if (textChild.nodeType === 1) {
+                                const textNode = (
+                                    textChild as Element
+                                ).getElementsByTagName("p");
+                                if (textNode.length !== 0) {
+                                    for (
+                                        let k = 0;
+                                        k < textNode.length;
+                                        k += 1
+                                    ) {
+                                        text.push(textNode[k].textContent);
+                                    }
+                                } else {
+                                    const textToHtmlElement = (
+                                        textChild as Element
+                                    )?.querySelector(
+                                        ".text_to_html"
+                                    ) as Element | null;
+                                    if (textToHtmlElement) {
+                                        const textContent =
+                                            textToHtmlElement?.textContent;
+                                        if (textContent) {
+                                            text.push(textContent);
+                                        }
+                                    } else {
+                                        const textContent =
+                                            textChild.textContent;
+                                        if (textContent) {
+                                            text.push(textContent);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        quiz.correct = text.filter(
+                            (value) => value !== null
+                        ) as string[];
+                    }
+                }
+            }
+
+            // 選択肢問題の解答を取得
+            if (
+                container.querySelector(
+                    ".answer-correct .form-control-static"
+                ) ||
+                container.querySelector(
+                    ".answer-incorrect .form-control-static"
+                )
+            ) {
+                const answerElement =
+                    container.querySelector(
+                        ".answer-correct .form-control-static"
+                    ) ||
+                    container.querySelector(
+                        ".answer-incorrect .form-control-static"
+                    );
+                const answerChilds = answerElement?.childNodes ?? [];
+                const text = [];
+                for (let j = 0; j < answerChilds.length; j += 1) {
+                    const textChild = answerChilds[j];
+                    if (textChild.nodeType === 1) {
+                        const textNode = (
+                            textChild as Element
+                        ).getElementsByTagName("p");
+                        if (textNode.length !== 0) {
+                            for (let k = 0; k < textNode.length; k += 1) {
+                                text.push(textNode[k].textContent);
+                            }
+                        } else {
+                            const textToHtmlElement = (
+                                textChild as Element
+                            )?.querySelector(".text_to_html") as Element | null;
+                            if (textToHtmlElement) {
+                                const textContent =
+                                    textToHtmlElement?.textContent;
+                                if (textContent) {
+                                    text.push(textContent);
+                                }
+                            } else {
+                                const textContent = textChild.textContent;
+                                if (textContent) {
+                                    text.push(textContent);
+                                }
+                            }
+                        }
+                    }
+                }
+                quiz.answer = text.filter(
+                    (value) => value !== null
+                ) as string[];
+            }
+
+            // 画像の抽出
+            const imageElement = container.querySelectorAll("img");
+            if (imageElement.length !== 0) {
+                quiz.image = [];
+                imageElement.forEach((image) => {
+                    const src = image.src;
+                    //@ts-ignore quiz.imageは-3行部分で初期化しているため、undefinedではない
+                    quiz.image.push(src);
+                });
+            }
+
+            // 記述問題の解答例と回答の抽出
+            if (quiz.choices.length === 0) {
+                const answerElements = container.querySelectorAll(
+                    ".form-control-static .text_to_html"
+                );
+                if (answerElements[1]) {
+                    const correctChilds = answerElements[1].childNodes;
+                    const text = [];
+                    for (let j = 0; j < correctChilds.length; j += 1) {
+                        const textChild = correctChilds[j];
+                        if (textChild.nodeType === 1) {
+                            const textNode = (
+                                textChild as Element
+                            ).querySelectorAll("p");
+                            if (textNode.length !== 0) {
+                                for (let k = 0; k < textNode.length; k += 1) {
+                                    text.push(textNode[k].textContent);
+                                }
+                            } else {
+                                const textToHtmlElement = (
+                                    textChild as Element
+                                )?.querySelector(
+                                    ".text_to_html"
+                                ) as Element | null;
+                                if (textToHtmlElement) {
+                                    const textContent =
+                                        textToHtmlElement?.textContent;
+                                    if (textContent) {
+                                        text.push(textContent);
+                                    }
+                                } else {
+                                    const textContent = textChild.textContent;
+                                    if (textContent) {
+                                        text.push(textContent);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    quiz.correct = text.filter(
+                        (value) => value !== null
+                    ) as string[];
+                }
+                if (answerElements[2]) {
+                    const answerChilds = answerElements[2].childNodes;
+                    const text = [];
+                    for (let j = 0; j < answerChilds.length; j += 1) {
+                        const textChild = answerChilds[j];
+                        if (textChild.nodeType === 1) {
+                            const textNode = (
+                                textChild as Element
+                            ).querySelectorAll("p");
+                            if (textNode.length !== 0) {
+                                for (let k = 0; k < textNode.length; k += 1) {
+                                    text.push(textNode[k].textContent);
+                                }
+                            } else {
+                                const textToHtmlElement = (
+                                    textChild as Element
+                                )?.querySelector(
+                                    ".text_to_html"
+                                ) as Element | null;
+                                if (textToHtmlElement) {
+                                    const textContent =
+                                        textToHtmlElement?.textContent;
+                                    if (textContent) {
+                                        text.push(textContent);
+                                    }
+                                } else {
+                                    const textContent = textChild.textContent;
+                                    if (textContent) {
+                                        text.push(textContent);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    quiz.answer = text.filter(
+                        (value) => value !== null
+                    ) as string[];
+                }
+            }
+
+            // If either quiz.correct or quiz.answer is null, the other must be also null.
+            if (quiz.correct === undefined || quiz.answer === undefined) {
+                quiz.correct = undefined;
+                quiz.answer = undefined;
+            }
+
+            quizzes.push(quiz);
+        });
+
+        return quizzes;
+    }
+})();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -117,7 +117,7 @@ interface GetCalendarUpcomingViewRes extends MoodleServiceRes {
 }
 
 // meaQsの型
-interface Quiz {
+interface MeaQsQuiz {
     index: number;
     question: string[];
     choices?: string[[]];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -116,6 +116,17 @@ interface GetCalendarUpcomingViewRes extends MoodleServiceRes {
     }
 }
 
+// meaQsの型
+interface Quiz {
+    index: number;
+    question: string[];
+    choices?: string[[]];
+    correct?: string[];
+    answer?: string[];
+    image?: string[];
+}
+
+
 type ParsedAssignments = {
     eventId: number;
     instanceId: number;
@@ -152,3 +163,4 @@ type PostMessageDataFromInjectedScript = {
         type: 'moodlePlus:misc:injectedScriptLoaded';
     }
 }
+

--- a/styles/leaQs.css
+++ b/styles/leaQs.css
@@ -1,0 +1,101 @@
+body {
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 20px;
+  background-color: #e4ebee;
+}
+
+#container {
+  max-width: 1200px;
+  margin: 0 auto;
+  background-color: #fff;
+  padding: clamp(16px, 5%, 12px);
+  border-radius: 5px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  display: grid;
+  column-gap: clamp(16px, 5%, 12px);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  align-items: stretch;
+}
+
+.quiz-item {
+  border-bottom: 1px solid #ddd;
+  min-height: 200px;
+  padding-bottom: 10px;
+  page-break-inside: avoid;
+}
+
+.quiz-question {
+  color: #333;
+  margin: 10px 0px 30px 50px;
+}
+
+.quiz-example {
+  color: #00548f;
+  font-weight: bold;
+}
+
+.quiz-userAnswer-correct {
+  color: #207224;
+  font-style: italic;
+}
+
+.quiz-userAnswer-incorrect {
+  color: #af6715;
+  font-style: italic;
+}
+
+h1 {
+  color: #333;
+  grid-column: 1 / -1;
+  font-size: medium;
+}
+
+h2 {
+  z-index: 6;
+  color: #444;
+  font-size: small;
+  position: absolute;
+}
+
+img {
+  max-width: 48%;
+  height: auto;
+  margin: 10px 0;
+  display: inline-block;
+}
+
+ul {
+  padding-left: 20px;
+  margin: 0px;
+  list-style: lower-alpha;
+}
+
+li {
+  margin: 10px 0;
+}
+
+p {
+  margin: 0;
+}
+
+@media print {
+  body {
+    background-color: #fff;
+  }
+
+  #container {
+    padding: clamp(16px, 5%, 12px);
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    display: grid;
+    column-gap: clamp(16px, 5%, 12px);
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    align-items: stretch;
+  }
+
+  .quiz-item {
+    page-break-inside: avoid;
+  }
+}


### PR DESCRIPTION
meaQsの出力を強化する拡張機能を追加しました。
meaQsデフォルトの確認画面やPDF出力に含まれる要素を見直し、よりも見やすいように整形したページを表示します｡
<img width="490" alt="SCR-20240829-canz-2" src="https://github.com/user-attachments/assets/1225cfc4-0599-424f-9036-29edcd38def8">
従来のmeaQsに出力用のボタンを追加し、ボタンのクリック時にページ内容を元に、新規ページを作成します｡
<img width="490" alt="image" src="https://github.com/user-attachments/assets/2583882a-3bc4-41c8-8ce4-f5c37ce71e8d">
生成されるページはよりUXを強化し、通常時での問題の表示数はもちろん、以下のようなウィンドウの状態でもすっきりと画面に収める事ができるようになっています｡
<img width="212" alt="SCR-20240829-canz-3" src="https://github.com/user-attachments/assets/088b9f20-e7a4-4fee-881b-930152b8bf60">
<img width="212" alt="SCR-20240829-canz" src="https://github.com/user-attachments/assets/99f1e6c2-528e-48cc-8a2d-aaac83ccf431">
