### PR TITLE
fix(wwwomu-rewrite): リンクが拡張機能によって追加された旨を明記

### DIFF
--- a/src/entrypoints/www-omu-ac-jp-rewrite.content/main.css
+++ b/src/entrypoints/www-omu-ac-jp-rewrite.content/main.css
@@ -16,3 +16,14 @@
     color: #fff;
     opacity: 1;
 }
+
+.__moodle_plus__omub::before {
+    content: '※Moodle Plusが追加したリンクです';
+    position: absolute;
+    bottom: 4px;
+    left: 4px;
+    font-size: 0.8rem;
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.7);
+    pointer-events: none;
+}


### PR DESCRIPTION
## What

<img width="502" height="396" alt="image" src="https://github.com/user-attachments/assets/de242f49-ddeb-4e03-afb8-190594f01312" />

## Why

公式リンクと誤認されるトラブル防止